### PR TITLE
ScrapValue apply to more scrap + Transmute to two-/one-handed scrap event is rarity based

### DIFF
--- a/BrutalCompanyMinus/Compatibility.cs
+++ b/BrutalCompanyMinus/Compatibility.cs
@@ -234,9 +234,8 @@ namespace BrutalCompanyMinus
             SurfacedPresent = IsModPresent("Surfaced", "Surfaced Detected");
             VarietyPresent = IsModPresent("TestAccount666.TestAccountVariety", "Test Account Variety Detected");
             CodeRebirthPresent = IsModPresent("CodeRebirth", "CodeRebirth Detected");
-            SuperEclipsePresent = IsModPresent("Millie.SuperEclipse", "Super Eclipse Detected")
+            SuperEclipsePresent = IsModPresent("Millie.SuperEclipse", "Super Eclipse Detected");
             ShipInventoryPresent = IsModPresent("ShipInventory", "Ship Inventory Detected. Including in inventory checks");
-
         }
 
         private static Assembly GetAssembly(string name)

--- a/BrutalCompanyMinus/Helpers.cs
+++ b/BrutalCompanyMinus/Helpers.cs
@@ -345,6 +345,32 @@ namespace BrutalCompanyMinus
             return hull;
         }
 
+        internal static SpawnableItemWithRarity? GetChosenScrap(Func<SpawnableItemWithRarity, bool> scrapSelector)
+            // i'd rather make TransmuteScrapEvent class and inherit it in TransmuteScrapSmall.cs and TrnasmuteScrapBig.cs,
+            // but this may break something and also make confusions, since it'll be a bit different from other events in this
+            // mod, best practice is to rewrite all events, but since I'm only making pull requests, I don't have much time for that.
+            // these two events are basically copy paste and that hurts my eyes D:
+        {
+            var oneHandedItems = RoundManager.Instance.currentLevel.spawnableScrap
+                .Where(scrapSelector)
+                .ToList();
+            var sumRarity = oneHandedItems.Sum(i => i.rarity);
+            var randomValue = UnityEngine.Random.Range(0, sumRarity);
+
+            var currentRarity = 0;
+            foreach (var item in oneHandedItems)
+            {
+                currentRarity += item.rarity;
+
+                if (currentRarity > randomValue)
+                    return item;
+            }
+
+            // Code should never reach this point
+            Log.LogError("Get chosen scrap could not find a random scrap to choose. Transmute events will not work.");
+            return null;
+        }
+
         private static Vector2 Sub(this Vector2 a, Vector2 b)
         {
             return a - b;

--- a/BrutalCompanyMinus/Minus/Events/TransmuteScrapBig.cs
+++ b/BrutalCompanyMinus/Minus/Events/TransmuteScrapBig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -44,16 +45,16 @@ namespace BrutalCompanyMinus.Minus.Events
         {
             Manager.scrapAmountMultiplier *= Getf(ScaleType.ScrapAmount);
 
-            List<SpawnableItemWithRarity> BigScrapList = new List<SpawnableItemWithRarity>();
-            foreach (SpawnableItemWithRarity item in RoundManager.Instance.currentLevel.spawnableScrap)
-            {
-                if (item.spawnableItem.twoHanded) BigScrapList.Add(item);
-            }
+            SpawnableItemWithRarity? chosenScrap = Helper.GetChosenScrap(ss => ss.spawnableItem.twoHanded);
+            if (chosenScrap is null) return;
 
-            SpawnableItemWithRarity chosenScrap = BigScrapList[UnityEngine.Random.Range(0, BigScrapList.Count)];
             chosenScrap.spawnableItem = Assets.GetItem(chosenScrap.spawnableItem.name);
 
-            Manager.TransmuteScrap(Getf(ScaleType.Percentage), new SpawnableItemWithRarity() { spawnableItem = chosenScrap.spawnableItem, rarity = 100 });
+            Manager.TransmuteScrap(Getf(ScaleType.Percentage), new SpawnableItemWithRarity()
+            {
+                spawnableItem = chosenScrap.spawnableItem,
+                rarity = 100
+            });
 
             // Scale scrap amount abit more
             float scrapValue = (chosenScrap.spawnableItem.minValue + chosenScrap.spawnableItem.maxValue) * 0.25f; // Intentionally

--- a/BrutalCompanyMinus/Minus/Events/TransmuteScrapSmall.cs
+++ b/BrutalCompanyMinus/Minus/Events/TransmuteScrapSmall.cs
@@ -44,16 +44,16 @@ namespace BrutalCompanyMinus.Minus.Events
         {
             Manager.scrapAmountMultiplier *= Getf(ScaleType.ScrapAmount);
 
-            List<SpawnableItemWithRarity> SmallScrapList = new List<SpawnableItemWithRarity>();
-            foreach (SpawnableItemWithRarity item in RoundManager.Instance.currentLevel.spawnableScrap)
-            {
-                if (!item.spawnableItem.twoHanded) SmallScrapList.Add(item);
-            }
+            SpawnableItemWithRarity? chosenScrap = Helper.GetChosenScrap(ss => !ss.spawnableItem.twoHanded);
+            if (chosenScrap is null) return;
 
-            SpawnableItemWithRarity chosenScrap = SmallScrapList[UnityEngine.Random.Range(0, SmallScrapList.Count)];
             chosenScrap.spawnableItem = Assets.GetItem(chosenScrap.spawnableItem.name);
 
-            Manager.TransmuteScrap(Getf(ScaleType.Percentage), new SpawnableItemWithRarity() { spawnableItem = chosenScrap.spawnableItem, rarity = 100 });
+            Manager.TransmuteScrap(Getf(ScaleType.Percentage), new SpawnableItemWithRarity()
+            {
+                spawnableItem = chosenScrap.spawnableItem,
+                rarity = 100
+            });
 
             // Scale scrap amount abit more
             float scrapValue = (chosenScrap.spawnableItem.minValue + chosenScrap.spawnableItem.maxValue) * 0.25f; // Intentionally

--- a/BrutalCompanyMinus/Minus/Handlers/Enemies/RedLocustBeesPatcher.cs
+++ b/BrutalCompanyMinus/Minus/Handlers/Enemies/RedLocustBeesPatcher.cs
@@ -1,17 +1,36 @@
 ﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using System.Reflection;
 using UnityEngine;
-using Unity.Netcode;
 
 namespace BrutalCompanyMinus.Minus.Handlers.Enemies
 {
     [HarmonyPatch(typeof(RedLocustBees))]
     internal static class RedLocustBeesPatcher
     {
-        [HarmonyPrefix]
+        [HarmonyTranspiler]
         [HarmonyPatch(nameof(RedLocustBees.SpawnHiveClientRpc))]
-        internal static void IncreaseHiveScrapValue(NetworkObjectReference hiveObject, ref int hiveScrapValue, Vector3 hivePosition)
+        internal static IEnumerable<CodeInstruction> IncreaseHiveScrapValue(IEnumerable<CodeInstruction> instructions)
         {
-            hiveScrapValue = Mathf.RoundToInt(hiveScrapValue * Manager.scrapValueMultiplier);
+            var scrapValueMultiplier = typeof(Manager).GetField(nameof(Manager.scrapValueMultiplier), BindingFlags.Static | BindingFlags.NonPublic);
+            var roundMethod = typeof(Mathf).GetMethod(nameof(Mathf.RoundToInt));
+
+            var found = false;
+            foreach (var instruction in instructions)
+            {
+                if (instruction.IsLdarg(2) && !found)
+                {
+                    found = true;
+                    yield return new CodeInstruction(OpCodes.Ldarg_2);                          // push 'hiveScrapValue' to stack
+                    yield return new CodeInstruction(OpCodes.Conv_R4);                          // converting 'hiveScrapValue' to float32
+                    yield return new CodeInstruction(OpCodes.Ldsfld, scrapValueMultiplier);     // push bcmer multiplier to stack
+                    yield return new CodeInstruction(OpCodes.Mul);                              // multiply bcmer multiplier and 'hiveScrapValue'
+                    yield return new CodeInstruction(OpCodes.Call, roundMethod);                // round result to Int32, since 'hiveScrapValue' is an integer
+                    yield return new CodeInstruction(OpCodes.Starg, 2);                         // save result to 'hiveScrapValue'
+                }
+                yield return instruction;
+            }
         }
     }
 }

--- a/BrutalCompanyMinus/Minus/Handlers/Enemies/RedLocustBeesPatcher.cs
+++ b/BrutalCompanyMinus/Minus/Handlers/Enemies/RedLocustBeesPatcher.cs
@@ -1,0 +1,17 @@
+﻿using HarmonyLib;
+using UnityEngine;
+using Unity.Netcode;
+
+namespace BrutalCompanyMinus.Minus.Handlers.Enemies
+{
+    [HarmonyPatch(typeof(RedLocustBees))]
+    internal static class RedLocustBeesPatcher
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(RedLocustBees.SpawnHiveClientRpc))]
+        internal static void IncreaseHiveScrapValue(NetworkObjectReference hiveObject, ref int hiveScrapValue, Vector3 hivePosition)
+        {
+            hiveScrapValue = Mathf.RoundToInt(hiveScrapValue * Manager.scrapValueMultiplier);
+        }
+    }
+}

--- a/BrutalCompanyMinus/Minus/MonoBehaviours/GrabbableLandmine.cs
+++ b/BrutalCompanyMinus/Minus/MonoBehaviours/GrabbableLandmine.cs
@@ -94,7 +94,9 @@ namespace BrutalCompanyMinus.Minus.MonoBehaviours
 
                 Net.Instance.GenerateAndSyncTerminalCodeServerRpc(__instance.NetworkObject, rng.Next(RoundManager.Instance.possibleCodesForBigDoors.Length));
 
-                Net.Instance.SyncScrapValueServerRpc(netObject, (int)(UnityEngine.Random.Range(Assets.grabbableLandmine.minValue, Assets.grabbableLandmine.maxValue + 1) * RoundManager.Instance.scrapValueMultiplier));
+                int scrapValue = UnityEngine.Random.Range(Assets.grabbableLandmine.minValue, Assets.grabbableLandmine.maxValue + 1);
+                int multipliedScrapValue = Mathf.RoundToInt(scrapValue * RoundManager.Instance.scrapValueMultiplier * Manager.scrapValueMultiplier);
+                Net.Instance.SyncScrapValueServerRpc(netObject, multipliedScrapValue);
 
                 yield return new WaitForSeconds(5.0f);
 

--- a/BrutalCompanyMinus/Minus/MonoBehaviours/GrabbableTurret.cs
+++ b/BrutalCompanyMinus/Minus/MonoBehaviours/GrabbableTurret.cs
@@ -52,7 +52,9 @@ namespace BrutalCompanyMinus.Minus.MonoBehaviours
 
                 Net.Instance.GenerateAndSyncTerminalCodeServerRpc(__instance.NetworkObject, rng.Next(RoundManager.Instance.possibleCodesForBigDoors.Length));
 
-                Net.Instance.SyncScrapValueServerRpc(netObject, (int)(UnityEngine.Random.Range(Assets.grabbableTurret.minValue, Assets.grabbableTurret.maxValue + 1) * RoundManager.Instance.scrapValueMultiplier));
+                int scrapValue = UnityEngine.Random.Range(Assets.grabbableTurret.minValue, Assets.grabbableTurret.maxValue + 1);
+                int multipliedScrapValue = Mathf.RoundToInt(scrapValue * RoundManager.Instance.scrapValueMultiplier * Manager.scrapValueMultiplier);
+                Net.Instance.SyncScrapValueServerRpc(netObject, multipliedScrapValue);
 
                 yield return new WaitForSeconds(5.0f);
 

--- a/BrutalCompanyMinus/Plugin.cs
+++ b/BrutalCompanyMinus/Plugin.cs
@@ -1,20 +1,9 @@
-﻿using System;
-using HarmonyLib;
+﻿using HarmonyLib;
 using BepInEx;
 using UnityEngine;
 using System.Reflection;
-using System.Collections;
-using BrutalCompanyMinus.Minus;
-using System.Collections.Generic;
 using BrutalCompanyMinus.Minus.Handlers;
-using UnityEngine.Diagnostics;
-using GameNetcodeStuff;
-using Unity.Netcode;
-using UnityEngine.InputSystem.HID;
-using Discord;
-using System.Diagnostics;
 using BepInEx.Configuration;
-using System.Globalization;
 using static BrutalCompanyMinus.Configuration;
 
 namespace BrutalCompanyMinus
@@ -25,7 +14,7 @@ namespace BrutalCompanyMinus
     {
         private const string GUID = "SoftDiamond.BrutalCompanyMinusExtraReborn";
         private const string NAME = "BrutalCompanyMinusExtraReborn";
-        private const string VERSION = "0.21.6";
+        private const string VERSION = "0.21.9";
         private static readonly Harmony harmony = new Harmony(GUID);
 
         void Awake()


### PR DESCRIPTION
This pull request contains two improvements for BCMER:
- Now **Bee Hive**'s, **Grabbable Landmine**'s, **Grabbable Turret**'s and **Apparatice**'s scrap value will scale with ScrapValue multiplier stat.
- Now events `TransmuteScrapBig.cs` and `TransmuteScrapSmall.cs` will pick an item based on their rarities, instead of absolutely randomly picking them from list of possible items. With LCGoldScrap mod, it kept picking gold scrap all the time, because there are a lot of scrap variations, though they're very rare.

Tested my improvements in Singleplayer, everything works fine and as intended. Didn't test it in Multiplayer, but if any error arises due to these changes, me or someone else will open an [issue](https://github.com/TheSoftDiamond/BrutalCompanyMinusExtraReborn/issues) and I'll fix it.