### PR TITLE
LunarConfig compatibility for enemy weights + DawnLib hazard code update

### DIFF
--- a/BrutalCompanyMinus/BrutalCompanyMinus.csproj
+++ b/BrutalCompanyMinus/BrutalCompanyMinus.csproj
@@ -198,7 +198,7 @@
 	</ItemGroup>
 
 	<Target Name="NetcodePatch" AfterTargets="PostBuildEvent">
-		<Exec Command="netcode-patch -uv 2022.3.62 -nv 1.12.0 -tv 1.0.0 &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies->'&quot;%(Identity)&quot;', ' ')" />
+		<Exec Command="netcode-patch -uv 2022.3.62 -nv 1.12.2 -tv 1.0.0 &quot;$(TargetPath)&quot; @(ReferencePathWithRefAssemblies->'&quot;%(Identity)&quot;', ' ')" />
 	</Target>
 
 	<Target Name="CopyToPluginsFolder" AfterTargets="PostBuildEvent">

--- a/BrutalCompanyMinus/Minus/Handlers/CustomEvents/DawnLibHandling.cs
+++ b/BrutalCompanyMinus/Minus/Handlers/CustomEvents/DawnLibHandling.cs
@@ -1,12 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Reflection;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
-using System.Xml.Linq;
 using BrutalCompanyMinus.Minus.CustomEvents;
 using Dawn;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace BrutalCompanyMinus.Minus.Handlers.CustomEvents
 {
@@ -23,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Handlers.CustomEvents
         {
             public object OutsideWeights;
             public object InsideWeights;
-            public bool FacingAway, FacingWall, BackToWall, BackFlush, ReqDist, DisallowNear;
+            public bool FacingAway, FacingWall, BackToWall, BackFlush, ReqDist, DisallowNear, AllowInMineshaft;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
@@ -53,7 +49,8 @@ namespace BrutalCompanyMinus.Minus.Handlers.CustomEvents
             bool managed = false;
             foreach (DawnMapObjectInfo mapObjectInfo in LethalContent.MapObjects.Values)
             {
-                if (mapObjectInfo.ShouldSkipIgnoreOverride() || mapObjectInfo.MapObject.name != hazardName)
+                GameObject? mapObject = mapObjectInfo.GetMapObjectPrefab();
+                if (mapObjectInfo.ShouldSkipIgnoreOverride() || mapObject == null || mapObject.name != hazardName)
                     continue;
 
                 DawnOutsideMapObjectInfo? outsideInfo = mapObjectInfo.OutsideInfo;
@@ -76,10 +73,12 @@ namespace BrutalCompanyMinus.Minus.Handlers.CustomEvents
             bool processed = false;
             foreach (DawnMapObjectInfo mapObjectInfo in LethalContent.MapObjects.Values)
             {
-                if (mapObjectInfo.ShouldSkipIgnoreOverride() || mapObjectInfo.MapObject.name != hazard.hazardObject.name)
+                GameObject? mapObject = mapObjectInfo.GetMapObjectPrefab();
+                if (mapObjectInfo.ShouldSkipIgnoreOverride() || mapObject == null || mapObject.name != hazard.hazardObject.name)
                     continue;
 
-                string hazardName = mapObjectInfo.MapObject.name;
+                string hazardName = mapObject.name;
+                IndoorMapHazardType? indoorMapHazardType = mapObjectInfo.InsideInfo?.IndoorMapHazardType;
 
                 if (!originalStates.ContainsKey(hazardName))
                 {
@@ -87,12 +86,13 @@ namespace BrutalCompanyMinus.Minus.Handlers.CustomEvents
                     {
                         OutsideWeights = mapObjectInfo.OutsideInfo?.SpawnWeights,
                         InsideWeights = mapObjectInfo.InsideInfo?.SpawnWeights,
-                        FacingAway = mapObjectInfo.InsideInfo?.SpawnFacingAwayFromWall ?? false,
-                        FacingWall = mapObjectInfo.InsideInfo?.SpawnFacingWall ?? false,
-                        BackToWall = mapObjectInfo.InsideInfo?.SpawnWithBackToWall ?? false,
-                        BackFlush = mapObjectInfo.InsideInfo?.SpawnWithBackFlushAgainstWall ?? false,
-                        ReqDist = mapObjectInfo.InsideInfo?.RequireDistanceBetweenSpawns ?? false,
-                        DisallowNear = mapObjectInfo.InsideInfo?.DisallowSpawningNearEntrances ?? false
+                        FacingAway = indoorMapHazardType?.spawnFacingAwayFromWall ?? false,
+                        FacingWall = indoorMapHazardType?.spawnFacingWall ?? false,
+                        BackToWall = indoorMapHazardType?.spawnWithBackToWall ?? false,
+                        BackFlush = indoorMapHazardType?.spawnWithBackFlushAgainstWall ?? false,
+                        ReqDist = indoorMapHazardType?.requireDistanceBetweenSpawns ?? false,
+                        DisallowNear = indoorMapHazardType?.disallowSpawningNearEntrances ?? false,
+                        AllowInMineshaft = indoorMapHazardType?.allowInMineshaft ?? false
                     };
                 }
 
@@ -101,7 +101,7 @@ namespace BrutalCompanyMinus.Minus.Handlers.CustomEvents
 
                 NamespacedKey<DawnMoonInfo> moonKey = RoundManager.Instance.currentLevel.GetDawnInfo().TypedKey;
 
-                float computedWeight = UnityEngine.Random.Range(
+                float computedWeight = Random.Range(
                     hazard.minDensity.Computef(hazard.Type),
                     hazard.maxDensity.Computef(hazard.Type)
                 );
@@ -126,12 +126,13 @@ namespace BrutalCompanyMinus.Minus.Handlers.CustomEvents
                     insideInfo.SpawnWeights = new CurveTableBuilder<DawnMoonInfo, SpawnWeightContext>()
                         .AddCurve(moonKey, AnimationCurve.Constant(0, 1, insideWeight))
                         .Build();
-                    insideInfo.SpawnFacingAwayFromWall = hazard.facingAwayFromWall;
-                    insideInfo.SpawnFacingWall = hazard.facingWall;
-                    insideInfo.SpawnWithBackToWall = hazard.backToWall;
-                    insideInfo.SpawnWithBackFlushAgainstWall = hazard.backFlushWithWall;
-                    insideInfo.RequireDistanceBetweenSpawns = hazard.requireDistanceBetween;
-                    insideInfo.DisallowSpawningNearEntrances = hazard.disallowNearEntrances;
+                    insideInfo.IndoorMapHazardType.spawnFacingAwayFromWall = hazard.facingAwayFromWall;
+                    insideInfo.IndoorMapHazardType.spawnFacingWall = hazard.facingWall;
+                    insideInfo.IndoorMapHazardType.spawnWithBackToWall = hazard.backToWall;
+                    insideInfo.IndoorMapHazardType.spawnWithBackFlushAgainstWall = hazard.backFlushWithWall;
+                    insideInfo.IndoorMapHazardType.requireDistanceBetweenSpawns = hazard.requireDistanceBetween;
+                    insideInfo.IndoorMapHazardType.disallowSpawningNearEntrances = hazard.disallowNearEntrances;
+                    insideInfo.IndoorMapHazardType.allowInMineshaft = hazard.allowInMineshaft;
 
                     mapObjectInfo.InsideInfo = insideInfo;
                     processed = true;
@@ -156,7 +157,8 @@ namespace BrutalCompanyMinus.Minus.Handlers.CustomEvents
             {
                 foreach (DawnMapObjectInfo mapObjectInfo in LethalContent.MapObjects.Values)
                 {
-                    if (mapObjectInfo.MapObject.name == entry.Key)
+                    GameObject? mapObject = mapObjectInfo.GetMapObjectPrefab();
+                    if (mapObject != null && mapObject.name == entry.Key)
                     {
                         if (mapObjectInfo.OutsideInfo != null)
                             mapObjectInfo.OutsideInfo.SpawnWeights = (ProviderTable<AnimationCurve?, DawnMoonInfo, SpawnWeightContext>?)entry.Value.OutsideWeights;
@@ -164,12 +166,15 @@ namespace BrutalCompanyMinus.Minus.Handlers.CustomEvents
                         if (mapObjectInfo.InsideInfo != null)
                         {
                             mapObjectInfo.InsideInfo.SpawnWeights = (ProviderTable<AnimationCurve?, DawnMoonInfo, SpawnWeightContext>?)entry.Value.InsideWeights;
-                            mapObjectInfo.InsideInfo.SpawnFacingAwayFromWall = entry.Value.FacingAway;
-                            mapObjectInfo.InsideInfo.SpawnFacingWall = entry.Value.FacingWall;
-                            mapObjectInfo.InsideInfo.SpawnWithBackToWall = entry.Value.BackToWall;
-                            mapObjectInfo.InsideInfo.SpawnWithBackFlushAgainstWall = entry.Value.BackFlush;
-                            mapObjectInfo.InsideInfo.RequireDistanceBetweenSpawns = entry.Value.ReqDist;
-                            mapObjectInfo.InsideInfo.DisallowSpawningNearEntrances = entry.Value.DisallowNear;
+
+                            IndoorMapHazardType indoorMapHazardType = mapObjectInfo.InsideInfo.IndoorMapHazardType;
+                            indoorMapHazardType.spawnFacingAwayFromWall = entry.Value.FacingAway;
+                            indoorMapHazardType.spawnFacingWall = entry.Value.FacingWall;
+                            indoorMapHazardType.spawnWithBackToWall = entry.Value.BackToWall;
+                            indoorMapHazardType.spawnWithBackFlushAgainstWall = entry.Value.BackFlush;
+                            indoorMapHazardType.requireDistanceBetweenSpawns = entry.Value.ReqDist;
+                            indoorMapHazardType.disallowSpawningNearEntrances = entry.Value.DisallowNear;
+                            indoorMapHazardType.allowInMineshaft = entry.Value.AllowInMineshaft;
                         }
                         break;
                     }

--- a/BrutalCompanyMinus/Minus/Handlers/Modded/LunarConfigCompat.cs
+++ b/BrutalCompanyMinus/Minus/Handlers/Modded/LunarConfigCompat.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using HarmonyLib;
+
+namespace BrutalCompanyMinus.Minus.Handlers.Modded;
+
+/// <summary>
+/// Applies current day enemy pool after DawnLib/LunarConfig changes the moon enemy pools
+/// </summary>
+[HarmonyPatch]
+internal class LunarConfigCompat
+{
+    private static readonly List<EnemyPool> enemyPools = [];
+    private static bool applying;
+
+    [HarmonyPatch(typeof(Manager), "DoAddEnemyToPoolWithRarity")]
+    [HarmonyPostfix]
+    private static void DoAddEnemyToPoolWithRarityPostfix(ref List<SpawnableEnemyWithRarity> list, EnemyType enemy, int rarity)
+    {
+        RoundManager roundManager = RoundManager.Instance;
+
+        if (applying || !Compatibility.DawnLibPresent || roundManager == null || roundManager.currentLevel == null || list == null || enemy == null || enemy.enemyPrefab == null)
+            return;
+
+        SelectableLevel currentLevel = roundManager.currentLevel;
+        EnemyPoolList poolList;
+        if (ReferenceEquals(list, currentLevel.Enemies))
+        {
+            poolList = EnemyPoolList.Inside;
+        }
+        else if (ReferenceEquals(list, currentLevel.OutsideEnemies))
+        {
+            poolList = EnemyPoolList.Outside;
+        }
+        else if (ReferenceEquals(list, currentLevel.DaytimeEnemies))
+        {
+            poolList = EnemyPoolList.Daytime;
+        }
+        else
+        {
+            return;
+        }
+
+        enemyPools.Add(new EnemyPool(EnemyPoolType.Add, poolList, enemy, rarity, string.Empty));
+    }
+
+    [HarmonyPatch(typeof(Manager), "DoRemoveSpawn")]
+    [HarmonyPostfix]
+    private static void DoRemoveSpawnPostfix(string Name)
+    {
+        RoundManager roundManager = RoundManager.Instance;
+
+        if (applying || !Compatibility.DawnLibPresent || roundManager == null || roundManager.currentLevel == null || string.IsNullOrWhiteSpace(Name))
+            return;
+
+        enemyPools.Add(new EnemyPool(EnemyPoolType.Remove, EnemyPoolList.Inside, null!, 0, Name));
+    }
+
+    [HarmonyPatch(typeof(RoundManager), nameof(RoundManager.RefreshEnemiesList))]
+    [HarmonyPostfix]
+    private static void RefreshEnemiesListPostfix()
+    {
+        RoundManager roundManager = RoundManager.Instance;
+
+        if (!Compatibility.DawnLibPresent || roundManager == null || !roundManager.IsHost || roundManager.currentLevel == null || enemyPools.Count == 0)
+            return;
+
+        SelectableLevel currentLevel = roundManager.currentLevel;
+
+        try
+        {
+            applying = true;
+
+            foreach (EnemyPool enemyPool in enemyPools)
+            {
+                if (enemyPool.PoolType == EnemyPoolType.Remove)
+                {
+                    Manager.RemoveSpawn(enemyPool.EnemyName);
+                    continue;
+                }
+
+                List<SpawnableEnemyWithRarity> target = enemyPool.PoolList switch
+                {
+                    EnemyPoolList.Inside => currentLevel.Enemies,
+                    EnemyPoolList.Outside => currentLevel.OutsideEnemies,
+                    EnemyPoolList.Daytime => currentLevel.DaytimeEnemies,
+                    _ => throw new ArgumentOutOfRangeException(nameof(enemyPool.PoolList), enemyPool.PoolList, null),
+                };
+                Manager.AddEnemyToPoolWithRarity(ref target, enemyPool.EnemyType, enemyPool.Rarity);
+            }
+        }
+        catch (Exception exception)
+        {
+            Log.LogWarning("Failed to apply enemy pool changes after LunarConfig/DawnLib: " + exception);
+        }
+        finally
+        {
+            applying = false;
+        }
+    }
+
+    [HarmonyPatch(typeof(StartOfRound), nameof(StartOfRound.ShipLeave))]
+    [HarmonyPatch(typeof(StartOfRound), nameof(StartOfRound.OnLocalDisconnect))]
+    [HarmonyPostfix]
+    private static void CleanupPostfix()
+    {
+        enemyPools.Clear();
+    }
+
+    private enum EnemyPoolType
+    {
+        Add,
+        Remove
+    }
+
+    private enum EnemyPoolList
+    {
+        Inside,
+        Outside,
+        Daytime
+    }
+
+    private readonly struct EnemyPool
+    {
+        internal readonly EnemyPoolType PoolType;
+        internal readonly EnemyPoolList PoolList;
+        internal readonly EnemyType EnemyType;
+        internal readonly int Rarity;
+        internal readonly string EnemyName;
+
+        internal EnemyPool(EnemyPoolType poolType, EnemyPoolList poolList, EnemyType enemyType, int rarity, string enemyName)
+        {
+            PoolType = poolType;
+            PoolList = poolList;
+            EnemyType = enemyType;
+            Rarity = rarity;
+            EnemyName = enemyName;
+        }
+    }
+}


### PR DESCRIPTION
LunarConfig + DawnLib overwrite the moon enemy pool at `RoundManager.RefreshEnemiesList`, which is after BCMER events have ran. This adds a patch that caches BCMER enemy pool changes as they happen, then reapplies them after `RoundManager.RefreshEnemiesList`

Also updated DawnLib hazard code

I used harmony because editing `Manager.cs` is too scary. would be good to doublecheck if i overlooked anything, but have tested with no abnormalities so far:
- in-game over LAN with multiple clients open
- without LunarConfig + DawnLib installed
- with DawnLib only installed